### PR TITLE
Experiment: Try automatic infering of wrapper blocks

### DIFF
--- a/create-blocks/create-accordion-header-block.php
+++ b/create-blocks/create-accordion-header-block.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__ . '/util.php';
 
-function create_accordion_header_block( $attrs ) {
+function create_woocommerce_accordion_header_block( $attrs ) {
 	$block_type_name = 'woocommerce/accordion-header';
 
 	$attrs = filter_block_attributes( $block_type_name, $attrs );

--- a/create-blocks/create-accordion-item-block.php
+++ b/create-blocks/create-accordion-item-block.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__ . '/util.php';
 
-function create_accordion_item_block( $attrs, $inner_blocks = array() ) {
+function create_woocommerce_accordion_item_block( $attrs, $inner_blocks = array() ) {
 	$block_type_name = 'woocommerce/accordion-item';
 
 	$attrs = filter_block_attributes( $block_type_name, $attrs );

--- a/create-blocks/create-accordion-panel-block.php
+++ b/create-blocks/create-accordion-panel-block.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__ . '/util.php';
 
-function create_accordion_panel_block( $attrs, $inner_blocks = array() ) {
+function create_woocommerce_accordion_panel_block( $attrs, $inner_blocks = array() ) {
 	$block_type_name = 'woocommerce/accordion-panel';
 
 	$attrs = filter_block_attributes( $block_type_name, $attrs );

--- a/woo-block-hooks-experiments.php
+++ b/woo-block-hooks-experiments.php
@@ -28,6 +28,34 @@ add_filter(
 	4
 );
 
+function set_block_parent( $metadata ) {
+    // Only add the parent to our test block type.
+    if ( isset( $metadata['name'] ) && 'core/paragraph' === $metadata['name'] ) {
+		$metadata['parent'] = 'woocommerce/accordion-panel';
+    }
+	return $metadata;
+};
+add_filter( 'block_type_metadata', 'set_block_parent' );
+
+function find_block_wrapper_path( $ancestor, $descendant ) {
+	$ancestor_block_type_definition = WP_Block_Type_Registry::get_instance()->get_registered( $ancestor );
+	$allowed_blocks = $ancestor_block_type_definition->allowed_blocks ?? array();
+	if ( empty( $allowed_blocks ) || in_array( $descendant, $allowed_blocks, true ) ) {
+		// Check if the descendant also lists the ancestor as its parent.
+		$descendant_block_type_definition = WP_Block_Type_Registry::get_instance()->get_registered( $descendant );
+		if ( ! empty( $descendant_block_type_definition->parent ) && $ancestor === $descendant_block_type_definition->parent ) {
+			return array( $descendant);
+		}
+	}
+
+	foreach ( $allowed_blocks as $allowed_block ) {
+		$path = find_block_wrapper_path( $allowed_block, $descendant );
+		if ( ! empty( $path ) ) {
+			return array_merge( array( $allowed_block ), $path );
+		}
+	}
+}
+
 add_filter(
 	'hooked_block_core/paragraph',
 	function (
@@ -47,15 +75,18 @@ add_filter(
 		if ( 'woocommerce/accordion-group' === $parsed_anchor_block['blockName'] && $relative_position === 'last_child' ) {
 			$parsed_hooked_block['innerContent'] = array( '<p>Hello World!</p>' );
 
-			// We wrap our hooked paragraph block in an Accordion Panel block inside of an Accordion Item block.
-			$parsed_hooked_block = create_accordion_item_block(
-				array(), // Attributes for Accordion Item block.
-				array(
-					// Inner blocks of the Accordion Item block: Header and Panel.
-					create_accordion_header_block( array( 'title' => 'Accordion Header block' ) ),
-					create_accordion_panel_block( array(), array( $parsed_hooked_block ) )
-				)
-			);
+			$path = find_block_wrapper_path( $parsed_anchor_block['blockName'], $hooked_block_type );
+
+			$wrapper = $parsed_hooked_block;
+			array_pop( $path );
+			foreach( array_reverse( $path ) as $block ) {
+				$wrapper_block_function = 'create_' . str_replace( array( '/', '-' ) , '_', $block ) . '_block';
+				if ( function_exists( $wrapper_block_function ) ) {
+					$wrapper = call_user_func( $wrapper_block_function, array(), array( $wrapper ) );
+				}
+			}
+
+			$parsed_hooked_block = $wrapper;
 		}
 
 		return $parsed_hooked_block;


### PR DESCRIPTION
Work in progress. cc/ @dinhtungdu 

The idea is that if a block (e.g. `3rd-party-block`) is supposed to be added to a container block that has an `allowedBlocks` property that doesn't include that 3rd party block, we assume that the latter needs to be wrapped in one of the `allowedBlocks`. This might go across multiple layers of block wrappers, e.g.

![Screenshot 2025-04-29 at 14 51 51](https://github.com/user-attachments/assets/db2d07f7-34d4-49e4-a92e-7f6202c57318)

In the above scenario, the 3rd party block needs to be wrapped in an Accordion Panel block, which needs to be wrapped in an Accordion Item block. Only then can the latter be added to the existing Accordion Group block.

More details to follow.

---

Note that there's currently a conceptual issue: The Accordion Item’s allowed blocks are [Accordion Header and Accordion Panel](https://github.com/woocommerce/woocommerce/blob/12de7aba167f7b45f69a13b152e9fce19026e1ca/plugins/woocommerce/client/blocks/assets/js/blocks/accordion/inner-blocks/accordion-item/block.json#L12-L15).

That means that while we can use `parent`/`allowedBlocks` information to wrap a 3rd party block in an Accordion Panel (and subsequently, that block in an Accordion Item) before appending it to the target Accordion Group anchor block, we’re missing a mechanism to provide some ancillary information that’s crucial here — the title used for the Accordion Header block. We will look into solutions to this problem separately.