### PR TITLE
Experiment: Add On-Sale Badge via Block Hooks

### DIFF
--- a/woo-add-product-sale-badge.php
+++ b/woo-add-product-sale-badge.php
@@ -34,3 +34,18 @@ add_filter(
     10,
     4
 );
+
+add_filter( 'woocommerce_product_sale_badge_label', function( $badge_text, $product ) {
+	$regular_price = $product->get_regular_price();
+	$sale_price    = $product->get_sale_price();
+
+	$percentage_off = ( $regular_price - $sale_price ) / $regular_price * 100;
+
+	if ( $percentage_off > 5 ) {
+		$badge_text = round( $percentage_off ) . '%';
+	} else {
+		$badge_text = '%';
+	}
+
+	return $badge_text;
+}, 10, 2 );

--- a/woo-add-product-sale-badge.php
+++ b/woo-add-product-sale-badge.php
@@ -28,7 +28,6 @@ add_filter(
         if ( 'woocommerce/product-image' === $parsed_anchor_block['blockName'] && 'first_child' === $relative_position ) {
             $parsed_hooked_block['attrs']['isDescendentOfQueryLoop'] = true;
             $parsed_hooked_block['attrs']['isDescendentOfSingleProductTemplate'] = true;
-            $parsed_hooked_block['attrs']['metadata']['extra'] = $parsed_anchor_block['attrs'];
         }
         return $parsed_hooked_block;
     },

--- a/woo-add-product-sale-badge.php
+++ b/woo-add-product-sale-badge.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Plugin Name: Add Product Sale Badge to Product Image via Block Hooks
+ * Plugin URI: https://woocommerce.com/
+ * Author: Automattic
+ * Author URI: https://woocommerce.com
+ * Requires at least: 6.6
+ * Requires PHP: 7.4
+ *
+ * @package woocommerce-block-hooks-experiments
+ */
+
+add_filter(
+    'hooked_block_types',
+    function ( $hooked_block_types, $relative_position, $anchor_block_type ) {
+        if ( 'woocommerce/product-image' === $anchor_block_type && 'first_child' === $relative_position ) {
+            $hooked_block_types[] = 'woocommerce/product-sale-badge';
+        }
+        return $hooked_block_types;
+    },
+    10,
+    3
+);
+
+add_filter(
+    'hooked_block_woocommerce/product-sale-badge',
+    function( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block ) {
+        if ( 'woocommerce/product-image' === $parsed_anchor_block['blockName'] && 'first_child' === $relative_position ) {
+            $parsed_hooked_block['attrs']['isDescendentOfQueryLoop'] = true;
+            $parsed_hooked_block['attrs']['isDescendentOfSingleProductTemplate'] = true;
+            $parsed_hooked_block['attrs']['metadata']['extra'] = $parsed_anchor_block['attrs'];
+        }
+        return $parsed_hooked_block;
+    },
+    10,
+    4
+);


### PR DESCRIPTION
Picking up the conversation from https://github.com/woocommerce/woocommerce/issues/52982#issuecomment-2531604851, this experiment explores using Block Hooks to add the Product Badge block to the Product Image. **It requires [this branch](https://github.com/woocommerce/woocommerce/tree/feature/55996-add-inner-blocks-support-for-product-image-block) of the WooCommerce codebase in order for the Product Image block to support inner blocks.**

![product-sale-badge](https://github.com/user-attachments/assets/6a1376fe-1c22-4d32-9c5c-ce8561bebf3e)

**Note that while this looks pretty good at first glance, there's one major caveat -- see below.**

### Testing Instructions

- Make sure that your instance of WooCommerce is using the `feature/55996-add-inner-blocks-support-for-product-image-block` branch.
- View a single product. Verify that there is no "On Sale" badge on any of the products in the Related Products section -- even if they are on sale. (If there is, edit the template to remove it.)
- **Now edit the Single Product template to make the following change: Select the Product Image block (inside the Related Products block), and add a paragraph block as an inner block to it. (It can contain any arbitrary text, e.g. just whitespace.)**
- Install the file from this PR as a plugin and enable it.
- Navigate to the frontend and reload. The "On Sale" badge should now be automatically inserted on any product in the Related Products section that's on sale.
- Go back to the editor and reload. Delete the "On Sale" badge and save the template.
- Reload the single product page on the frontend, and verify that the "On Sale" badge is gone from all products in the "Related Products" section, thus reflecting the editor.

**Now for the caveat:** Insertion of a hooked block as `first_child` or `last_child` only works if the parent block already contains at least one other child block. (This limitation has mostly technical reasons.) This is currently not the case with the Product Image block -- it doesn't contain any inner blocks by default, which is why we had to insert the paragraph block in the testing instructions. Without it, the "On Sale" badge wouldn't be inserted by Block Hooks.

---

TODO:

- [ ] Find way to remove limitation of requiring another child block to be present.
- [ ] Allow setting badge label contextually, [e.g.](https://github.com/woocommerce/woocommerce/issues/52982#issuecomment-2522867001)

> 20% sale for products that cost 10 EUR
> 50% sale for products that cost 50 EUR.